### PR TITLE
Fix typo in logger name

### DIFF
--- a/packages/core/src/utils/monad.ts
+++ b/packages/core/src/utils/monad.ts
@@ -36,7 +36,7 @@ export function Ok<T>(value: T): Result<T> {
 }
 
 export function Err<T>(error: unknown): Result<T> {
-  useLogger('core:monnad').withError(error).warn('An error occurred')
+  useLogger('core:monad').withError(error).warn('An error occurred')
 
   return {
     orDefault: (defaultValue: T) => defaultValue,


### PR DESCRIPTION
## Summary
- fix mis-typed logger name in monad utils

## Testing
- `pnpm -r test` *(fails: EHOSTUNREACH)*